### PR TITLE
Добавление данных о количестве сокращённых рабочих дней в статистику

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ $calendarForDay = $calendar->getPeriodForDay(new DateTime('2024-01-01'));
 - `workDays` – количество рабочих дней в периоде;
 - `weekends` – количество выходных дней в периоде (без учета праздничных);
 - `holidays` – количество праздничных дней в периоде;
+- `shortenedWorkingDays` – количество сокращённых рабочих дней в периоде;
 - `workingHours` – количество рабочего времени за период.
 
 ```php
@@ -165,6 +166,7 @@ Shahruslan\ProductionCalendar\Entity\Period Object
             [workDays] => 1
             [weekends] => 0
             [holidays] => 2
+            [shortenedWorkingDays] => 0
             [workingHours] => 8
         )
 )

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $calendarForDay = $calendar->getPeriodForDay(new DateTime('2024-01-01'));
 use Shahruslan\ProductionCalendar\Calendar;
 
 $calendar = new Calendar('your-token');
-$period = $calendar->getPeriod('08.01.2024-10.01.2024', region: 23);
+$period = $calendar->getPeriod('07.01.2024-09.01.2024', region: 23);
 print_r($period);
 ```
 Output:

--- a/src/Entity/Statistic.php
+++ b/src/Entity/Statistic.php
@@ -15,6 +15,7 @@ final class Statistic
         public readonly int $workDays,
         public readonly int $weekends,
         public readonly int $holidays,
+        public readonly int $shortenedWorkingDays,
         public readonly int $workingHours,
     ) {}
 }

--- a/src/Factory/Factory.php
+++ b/src/Factory/Factory.php
@@ -35,6 +35,7 @@ final class Factory
             $data->statistic->work_days,
             $data->statistic->weekends,
             $data->statistic->holidays,
+            $data->statistic->shortened_working_days,
             $data->statistic->working_hours,
         );
 


### PR DESCRIPTION
Здравствуйте!

Для улучшения функциональности и точности статистики нашего проекта добавлено новое поле для подсчета количества сокращенных рабочих дней в API производственного календаря. Поскольку ваш SDK используется на проекте, нам необходимо добавить это поле также в класс статистики SDK.

Я подготовил пуллреквест с необходимыми изменениями и буду благодарен за его рассмотрение и, по возможности, включение в основную ветку проекта.

Спасибо!

С уважением,
Думитру

Скриншот данных с уже добавленным полем:
<img width="389" alt="Снимок экрана 2024-11-13 в 14 13 54" src="https://github.com/user-attachments/assets/86c8cb7c-2cf9-4e94-a10e-ee5f99f15597">

