### PR TITLE
Добавление поля "isProject" в сущность Day

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ $calendarForDay = $calendar->getPeriodForDay(new DateTime('2024-01-01'));
 - `type` - тип дня(праздничный, рабочий, выходной и тд);
 - `weekDay` - день недели;
 - `workingHours` - количество рабочих часов.
+- `isProject` - находится ли этот день в проекте закона и еще не утвержден.
 
 Свойство `statistic` отображает ряд статистических данных для задаваемого периода:
 - `calendarDays` – количество календарных дней в периоде;
@@ -117,6 +118,7 @@ Shahruslan\ProductionCalendar\Entity\Period Object
                             [value] => вс
                         )
                     [workingHours] => 0
+                    [isProject] => 0
                 )
             [1] => Shahruslan\ProductionCalendar\Entity\Day Object
                 (
@@ -137,6 +139,7 @@ Shahruslan\ProductionCalendar\Entity\Period Object
                             [value] => пн
                         )
                     [workingHours] => 0
+                    [isProject] => 0
                 )
             [2] => Shahruslan\ProductionCalendar\Entity\Day Object
                 (
@@ -157,6 +160,7 @@ Shahruslan\ProductionCalendar\Entity\Period Object
                             [value] => вт
                         )
                     [workingHours] => 8
+                    [isProject] => 0
                 )
         )
     [statistic] => Shahruslan\ProductionCalendar\Entity\Statistic Object

--- a/src/Entity/Day.php
+++ b/src/Entity/Day.php
@@ -18,5 +18,6 @@ final class Day
         public readonly DayType $type,
         public readonly WeekDay $weekDay,
         public readonly int $workingHours,
+        public readonly bool $isProject,
     ) {}
 }

--- a/src/Factory/Factory.php
+++ b/src/Factory/Factory.php
@@ -23,11 +23,11 @@ final class Factory
         $dateEnd = new DateTimeImmutable($data->dt_end);
 
         $days = array_map(static function ($day) {
-            $data = new DateTimeImmutable($day->date);
+            $date = new DateTimeImmutable($day->date);
             $type = DayType::from($day->type_text);
             $week = WeekDay::from($day->week_day);
             $isProject =  (bool) ($day->is_project ?? false);
-            return new Day($data, $type, $week, $day->working_hours, $isProject);
+            return new Day($date, $type, $week, $day->working_hours, $isProject);
         }, $data->days);
 
         $statistic = new Statistic(

--- a/src/Factory/Factory.php
+++ b/src/Factory/Factory.php
@@ -26,7 +26,8 @@ final class Factory
             $data = new DateTimeImmutable($day->date);
             $type = DayType::from($day->type_text);
             $week = WeekDay::from($day->week_day);
-            return new Day($data, $type, $week, $day->working_hours);
+            $isProject =  (bool) ($day->is_project ?? false);
+            return new Day($data, $type, $week, $day->working_hours, $isProject);
         }, $data->days);
 
         $statistic = new Statistic(


### PR DESCRIPTION
Здравствуйте!

В API присутствует поле `is_project` в данных дня, которое позволяет определить, что день находится в проекте закона и еще не утвержден. Однако в текущей версии SDK это поле отсутствует, из-за чего невозможно строить логику на основе данного значения.

В текущей реализации API возвращает поле `is_project` только в случае, если оно равно 1 (`true`). Для консистентности данных предлагаю сохранять его в формате `bool` и задавать значение `false` в случае отсутствия этого поля в ответе API. Если у вас есть другое видение того, как следует хранить данные для этого поля, пожалуйста, сообщите, чтобы я мог внести соответствующие изменения в реализацию.

Также в ходе добавления поля `isProject` я заметил небольшую опечатку в названии переменной по соседству. Если изменение данного нейминга является излишним, пожалуйста, сообщите, чтобы я мог вернуть предыдущий вариант.

Я подготовил пулл-реквест с предложенными изменениями и буду благодарен за его рассмотрение и возможное включение в основную ветку проекта.

Ниже примеры ответа API для утверждённых и не утверждённых дней:
<img width="377" alt="Снимок экрана 2024-11-18 в 13 33 46" src="https://github.com/user-attachments/assets/dd2efb4d-3b7d-428c-a436-9c5dbfedfffb">
<img width="383" alt="Снимок экрана 2024-11-18 в 13 34 15" src="https://github.com/user-attachments/assets/67d0616a-cf22-4e15-9513-3f5cb397b10d">
